### PR TITLE
Add ram override option

### DIFF
--- a/autogl/.env
+++ b/autogl/.env
@@ -10,3 +10,10 @@ MONGODB_VERSION=
 # Set Opensearch version. Defaults to latest:
 # (Note: this IS the "latest" tag!)
 OPENSEARCH_VERSION=
+
+# Memory assignments:
+GRAYLOG_MEMORY=
+OPENSEARCH_MEMORY=
+
+# Graylog root password, passthrough SHA256 hash:
+GRAYLOG_ROOT_PASSWORD_SHA2=

--- a/autogl/docker-compose.yml
+++ b/autogl/docker-compose.yml
@@ -47,19 +47,19 @@ services:
       GRAYLOG_SERVER_JAVA_OPTS: "-Xms${GRAYLOG_MEMORY}g -Xmx${GRAYLOG_MEMORY}g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow -Djdk.tls.acknowledgeCloseNotify=true -Dlog4j2.formatMsgNoLookups=true"
       GRAYLOG_MONGODB_URI: "mongodb://mongodb:27017/graylog"
     ports:
-      - "443:443/tcp"     # Server API
-      - "514:514/udp"     # Syslog UDP
-      - "514:514/tcp"     # Syslog TCP
-      - "5044:5044/tcp"   # Beats
-      - "5050:5050/tcp"   # RAW TCP
-      - "5050:5050/udp"   # RAW UDP
-      - "5555:5555/tcp"   # CEF TCP
-      - "5555:5555/udp"   # CEF UDP
-      - "5556:5556/tcp"   # Palo Alto Networks v9+ TCP
-      - "5557:5557/tcp"   # Palo Alto Networks v8.x TCP
-      - "9000:9000/tcp"   # Server API
-      - "12201:12201/tcp" # GELF TCP
-      - "12201:12201/udp" # GELF UDP
+      - "443:443/tcp"     # Server API encrpyted
+      #- "514:514/udp"     # Syslog UDP
+      #- "514:514/tcp"     # Syslog TCP
+      #- "5044:5044/tcp"   # Beats
+      #- "5050:5050/tcp"   # RAW TCP
+      #- "5050:5050/udp"   # RAW UDP
+      #- "5555:5555/tcp"   # CEF TCP
+      #- "5555:5555/udp"   # CEF UDP
+      #- "5556:5556/tcp"   # Palo Alto Networks v9+ TCP
+      #- "5557:5557/tcp"   # Palo Alto Networks v8.x TCP
+      - "9000:9000/tcp"   # Server API plaintext
+      #- "12201:12201/tcp" # GELF TCP
+      #- "12201:12201/udp" # GELF UDP
     networks:
       - graylog_network
     volumes:

--- a/autogl/docker-compose.yml
+++ b/autogl/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   opensearch:
     container_name: opensearch
     environment:
-      OPENSEARCH_JAVA_OPTS: "-Xms2g -Xmx2g -Dlog4j2.formatMsgNoLookups=true"
+      OPENSEARCH_JAVA_OPTS: "-Xms${OPENSEARCH_MEMORY}g -Xmx${OPENSEARCH_MEMORY}g -Dlog4j2.formatMsgNoLookups=true"
       bootstrap.memory_lock: "true"
       discovery.type: "single-node"
       http.host: "0.0.0.0"
@@ -33,7 +33,7 @@ services:
 
   graylog:
     container_name: graylog
-    image: "graylog/graylog-enterprise:6.0.3-1"
+    image: "graylog/graylog-enterprise:${GRAYLOG_VERSION}"
     depends_on:
       opensearch:
         condition: "service_started"
@@ -42,8 +42,9 @@ services:
     entrypoint: "/usr/bin/tini -- wait-for-it opensearch:9200 --  /docker-entrypoint.sh"
     environment:
       GRAYLOG_PASSWORD_SECRET: somepasswordpepper
-      GRAYLOG_ROOT_PASSWORD_SHA2: 941828f6268291fa3aa87a866e8367e609434f42761bdf02dc7fc7958897bae6
+      GRAYLOG_ROOT_PASSWORD_SHA2: ${GRAYLOG_ROOT_PASSWORD_SHA2}
       GRAYLOG_ELASTICSEARCH_HOSTS: "http://opensearch:9200"
+      GRAYLOG_SERVER_JAVA_OPTS: "-Xms${GRAYLOG_MEMORY}g -Xmx${GRAYLOG_MEMORY}g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow -Djdk.tls.acknowledgeCloseNotify=true -Dlog4j2.formatMsgNoLookups=true"
       GRAYLOG_MONGODB_URI: "mongodb://mongodb:27017/graylog"
     ports:
       - "443:443/tcp"     # Server API

--- a/autogl/gogograylog.sh
+++ b/autogl/gogograylog.sh
@@ -28,7 +28,7 @@ DGRAYBG='\033[0;100m' # dark gray background
 GRAYLOG_VERSION=
 OPENSEARCH_VERSION=
 MONGODB_VERSION=
-BRANCH="main"
+BRANCH="add-ram-override"
 
 # External system vars:
 LOG_FILE="/var/log/graylog-server/deploy-graylog.log"

--- a/autogl/gogograylog.sh
+++ b/autogl/gogograylog.sh
@@ -28,7 +28,7 @@ DGRAYBG='\033[0;100m' # dark gray background
 GRAYLOG_VERSION=
 OPENSEARCH_VERSION=
 MONGODB_VERSION=
-BRANCH="add-ram-override"
+BRANCH="main"
 
 # External system vars:
 LOG_FILE="/var/log/graylog-server/deploy-graylog.log"

--- a/autogl/gogograylog.sh
+++ b/autogl/gogograylog.sh
@@ -588,19 +588,25 @@ done
 # Clear current screen for cleanliness:
 clear
 
-echo -e "${BGREEN}Your Graylog Instance is up and running"'!'"${NC}\n"
-echo -e "Internal URL:\t ${UYELLOW}http://$INTERNAL_IP:9000${NC}"
-echo -e "External URL:\t ${UYELLOW}http://$EXTERNAL_IP:9000${NC}"
-echo -e "Default user:\t ${BCYAN}admin${NC}"
-echo -e "Password:\t ${BRED}$PSWD${NC}\n"
-echo -e "Docker Compose file:\t ${BGREEN}$(ls ~/docker-compose.yml)${NC}\n"
+echo -e "${BGREEN}Your Graylog Instance is up and running!${NC}"
+echo -e "Internal URL:\t\t${UYELLOW}http://$INTERNAL_IP:9000${NC}"
+echo -e "External URL:\t\t${UYELLOW}http://$EXTERNAL_IP:9000${NC}"
+echo -e "Default user:\t\t${BCYAN}admin${NC}"
+echo -e "Password:\t\t${BRED}$PSWD${NC}"
+echo -e "Docker Compose file:\t${BGREEN}$(ls ~/docker-compose.yml)${NC}"
+echo
 echo -e "To make changes, edit the compose file and run:"
 echo -e "${UYELLOW}docker compose -f ~/docker-compose.yml up -d${NC}"
 echo
+echo -e "Next Steps:"
+echo
+echo -e "\t1. Uncomment ports in $(ls ~/docker-compose.yml) to expose Inputs"
+echo -e "\t2. Send in logs"
+echo -e "\t3. Check out www.graylog.com for news and updates!"
+echo
 echo -e "Happy Logging!"
 echo
-echo -e " ${BCYAN}- The Graylog Team${NC}"
-echo
+echo -e "  ${BCYAN}- The Graylog Team${NC}\n"
 
 unset PSWD
 unset PSWD2


### PR DESCRIPTION
Added option for users to pass `--graylog-memory` and/or `--opensearch-memory` to specify how much RAM to give each container instead of using default values.

Default values have changed too:
- Graylog: 25% of system memory, up to 8 GB.
- OpenSearch: 50% of system memory, up to 31 GB.

Also, the memory units have changed from MB to GB, for sake of CLI usability. I decided it was easier and more common for users to specify RAM amounts in terms of GB instead of MB. This means there is no support for assigning partial GB amounts (e.g. 2.5 GB / 2560 MB), but I figured this is a very edge case anyway and not worth sacrificing usability.